### PR TITLE
Fix for digital_controller throwing an error with unavailable.html.erb

### DIFF
--- a/app/controllers/spree/digitals_controller.rb
+++ b/app/controllers/spree/digitals_controller.rb
@@ -1,5 +1,5 @@
 module Spree
-  class DigitalsController < Spree::BaseController
+  class DigitalsController < Spree::StoreController
     ssl_required :show
   
     def show


### PR DESCRIPTION
unavailable.html.erb throws an error with digital_controller when the link expires
