### PR TITLE
Changed permalink to slug in accordance with friendly_id gem

### DIFF
--- a/app/controllers/spree/admin/digitals_controller.rb
+++ b/app/controllers/spree/admin/digitals_controller.rb
@@ -1,11 +1,12 @@
 module Spree
-  class Admin::DigitalsController < Spree::Admin::ResourceController
-    belongs_to "spree/product", :find_by => :permalink
-    
-    protected
-      def location_after_save
-        spree.admin_product_digitals_path(@product)
-      end
+  module Admin
+    class DigitalsController < ResourceController
+      belongs_to "spree/product", :find_by => :slug
+      
+      protected
+        def location_after_save
+          spree.admin_product_digitals_path(@product)
+        end
 
       def permitted_resource_params
         params.require(:digital).permit(permitted_digital_attributes)

--- a/spec/controllers/admin/digitals_controller_spec.rb
+++ b/spec/controllers/admin/digitals_controller_spec.rb
@@ -17,7 +17,7 @@ describe Spree::Admin::DigitalsController do
 
       it "should display an empty page when no digitals exist" do
         variants_without_digitals
-        spree_get :index, product_id: product.permalink
+        spree_get :index, product_id: product.slug
       end
 
       it "should display list of digitals when they exist" do
@@ -28,7 +28,7 @@ describe Spree::Admin::DigitalsController do
     context "without non-master variants" do
 
       it "should display an empty page when the master variant is not digital" do
-        spree_get :index, product_id: product.permalink
+        spree_get :index, product_id: product.slug
         response.code.should == "200"
         response.body.should include("This product has no variants")
         response.body.should_not include('A digital version of this product currently exists')
@@ -36,7 +36,7 @@ describe Spree::Admin::DigitalsController do
 
       it "should display the variant details when the master is digital" do
         @digital = create :digital, :variant => product.master
-        spree_get :index, product_id: product.permalink
+        spree_get :index, product_id: product.slug
         response.code.should == "200"
         response.body.should include('A digital version of this product currently exists')
       end
@@ -50,7 +50,7 @@ describe Spree::Admin::DigitalsController do
 
       it 'creates a digital associated with the variant and product' do
         lambda {
-          spree_post :create, product_id: product.permalink, 
+          spree_post :create, product_id: product.slug, 
                               digital: { variant_id: variant.id, 
                                          attachment: upload_image('thinking-cat.jpg') }
           response.should redirect_to(spree.admin_product_digitals_path(product))
@@ -66,7 +66,7 @@ describe Spree::Admin::DigitalsController do
     context 'for a digital and product that exist' do
       it 'deletes the associated digital' do
         lambda {
-          spree_delete :destroy, product_id: product.permalink, id: digital.id
+          spree_delete :destroy, product_id: product.slug, id: digital.id
           response.should redirect_to(spree.admin_product_digitals_path(product))
         }.should change(Spree::Digital, :count).by(-1)
       end


### PR DESCRIPTION
Spree switched to using the friendly_id gem, which uses :slug instead of :permalink - these updates adhere to that change.

See https://github.com/spree/spree/issues/4167 for more details
