### PR TITLE
Updated the location of the order_tabs override

### DIFF
--- a/app/overrides/spree/admin/shared/_order_submenu/add_digital_versions_to_admin_product_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_submenu/add_digital_versions_to_admin_product_tabs.html.erb.deface
@@ -1,0 +1,8 @@
+<!-- insert_bottom "[data-hook='admin_order_tabs']" -->
+<% if can?(:update, @order) && @order.digital? %>
+  <li>
+  <%= link_to_with_icon 'icon-cloud', Spree.t(:reset_downloads, scope: 'digitals'), reset_digitals_admin_order_url(@order) %>
+  </li>
+<% end %>
+
+<!-- enabled -->

--- a/app/overrides/spree/admin/shared/_order_tabs/add_digital_versions_to_admin_product_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_tabs/add_digital_versions_to_admin_product_tabs.html.erb.deface
@@ -1,8 +1,0 @@
-<!-- insert_bottom "[data-hook='admin_order_tabs']" -->
-<% if can?(:update, @order) && @order.digital? %>
-  <li>
-  <%= button_link_to(Spree.t(:reset_downloads, scope: 'digitals'), reset_digitals_admin_order_url(@order)) %>
-  </li>
-<% end %>
-
-<!-- enabled -->


### PR DESCRIPTION
The override broke with change at spree/spree@22a70b6#diff-2f549f834ee39b2abfde52d8901b984c

Also, changed the link_to method to an icon, which matches the other order tabs.
