### PR TITLE
Only add a second link if the variant isn't the master

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -19,7 +19,7 @@ Spree::LineItem.class_eval do
     if(master.digital?)
       create_digital_links_for_variant(master)
     end
-    create_digital_links_for_variant(variant)
+    create_digital_links_for_variant(variant) unless variant.is_master
   end
 
   def create_digital_links_for_variant(variant)


### PR DESCRIPTION
I was getting duplicate links with a digital that was only a master variant.

This probably could use a basic spec, but I'm unsure of how to create a master variant with the factory - couldn't find an example to learn from, and I'm certainly still learning
