### PR TITLE
Inherit from ShippingCalculator and use correct shipping method name

### DIFF
--- a/app/models/spree/calculator/shipping/digital_delivery.rb
+++ b/app/models/spree/calculator/shipping/digital_delivery.rb
@@ -3,12 +3,12 @@ require_dependency 'spree/shipping_calculator'
 
 module Spree
   module Calculator::Shipping
-    class DigitalDelivery < Spree::Calculator::Shipping::FlatRate
+    class DigitalDelivery < ShippingCalculator
       def self.description
         Spree.t(:digital_delivery, scope: 'digital')
       end
 
-      def compute(object=nil)
+      def compute_package(package=nil)
         self.preferred_amount
       end
 
@@ -18,3 +18,5 @@ module Spree
     end
   end
 end
+
+

--- a/app/models/spree/calculator/shipping/digital_delivery.rb
+++ b/app/models/spree/calculator/shipping/digital_delivery.rb
@@ -4,6 +4,9 @@ require_dependency 'spree/shipping_calculator'
 module Spree
   module Calculator::Shipping
     class DigitalDelivery < ShippingCalculator
+      preference :amount, :decimal, default: 0
+      preference :currency, :string, default: ->{ Spree::Config[:currency] }
+
       def self.description
         Spree.t(:digital_delivery, scope: 'digital')
       end

--- a/spec/models/calculator/digital_delivery_spec.rb
+++ b/spec/models/calculator/digital_delivery_spec.rb
@@ -7,17 +7,17 @@ describe Spree::Calculator::Shipping::DigitalDelivery do
     Spree::Calculator::Shipping::DigitalDelivery.should respond_to(:description)
   end
 
-  context '#compute' do
+  context '#compute_package' do
     it 'should ignore the passed in object' do
       lambda {
-        subject.compute(double)
+        subject.compute_package(double)
       }.should_not raise_error
     end
 
     it 'should always return the preferred_amount' do
       amount_double = double
       subject.should_receive(:preferred_amount).and_return(amount_double)
-      subject.compute(double).should eq(amount_double)
+      subject.compute_package(double).should eq(amount_double)
     end
   end
 


### PR DESCRIPTION
These adjustments fixed the shipping calculator not showing up when creating a new shipping method for me. Changes were following the guide at http://guides.spreecommerce.com/developer/calculators.html