### PR TITLE
Spree master moved on to 3.0.0.beta

### DIFF
--- a/spree_digital.gemspec
+++ b/spree_digital.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_api'
   s.add_dependency 'spree_backend'
-  s.add_dependency 'spree_core', '~> 2.4.0.beta'
+  s.add_dependency 'spree_core', '~> 3.0.0.beta'
   s.add_dependency 'spree_frontend'
 
   # test suite


### PR DESCRIPTION
See https://github.com/spree/spree/commit/2f8555e0c3378eb459aa3f30986dace7b8c3ea12
