### PR TITLE
Redirect appropriately on validation error

### DIFF
--- a/app/controllers/spree/admin/digitals_controller.rb
+++ b/app/controllers/spree/admin/digitals_controller.rb
@@ -11,13 +11,8 @@ module Spree
           super
         else
           invoke_callbacks(:create, :fails)
-          respond_with(@object) do |format|
-            format.html do
-              flash.now[:error] = @object.errors.full_messages.join(", ")
-              render action: 'index'
-            end
-            format.js { render layout: false }
-          end
+          flash[:error] = @object.errors.full_messages.join(", ")
+          redirect_to location_after_save
         end
       end
 

--- a/app/controllers/spree/admin/digitals_controller.rb
+++ b/app/controllers/spree/admin/digitals_controller.rb
@@ -3,6 +3,24 @@ module Spree
     class DigitalsController < ResourceController
       belongs_to "spree/product", :find_by => :slug
       
+      def create
+        invoke_callbacks(:create, :before)
+        @object.attributes = permitted_resource_params
+
+        if @object.valid?
+          super
+        else
+          invoke_callbacks(:create, :fails)
+          respond_with(@object) do |format|
+            format.html do
+              flash.now[:error] = @object.errors.full_messages.join(", ")
+              render action: 'index'
+            end
+            format.js { render layout: false }
+          end
+        end
+      end
+
       protected
         def location_after_save
           spree.admin_product_digitals_path(@product)

--- a/app/models/spree/digital.rb
+++ b/app/models/spree/digital.rb
@@ -5,6 +5,7 @@ module Spree
 
     has_attached_file :attachment, path: ":rails_root/private/digitals/:id/:basename.:extension"
     do_not_validate_attachment_file_type :attachment
+    validates_attachment_presence :attachment
 
     if Paperclip::Attachment.default_options[:storage] == :s3
       attachment_definitions[:attachment][:s3_permissions] = :private

--- a/spec/controllers/admin/digitals_controller_spec.rb
+++ b/spec/controllers/admin/digitals_controller_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe Spree::Admin::DigitalsController do
         }.to change(Spree::Digital, :count).by(1)
       end
     end
+
+    context 'for an invalid object' do
+      it 'redirects to the index page' do
+        expect {
+          spree_post :create, product_id: product.slug, digital: { variant_id: product.master.id } # fail validation by not passing attachment
+          expect(response).to redirect_to(spree.admin_product_digitals_path(product))
+        }.to change(Spree::Digital, :count).by(0)
+      end
+    end
   end
 
   context '#destroy' do


### PR DESCRIPTION
If for some reason there is an error on the object validation, its best to redirect them appropriately. Otherwise you'll get a nasty error as there is no "new" template for digitals.

I was experiencing a validation error because of a bug in paperclip that I described here: https://github.com/spree-contrib/spree_digital/issues/79