### PR TITLE
update gemspec to match Versionfile (spree 3.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-0-stable'
+gem 'spree', github: 'spree/spree', branch: 'master'
 
 gemspec
 

--- a/spree_digital.gemspec
+++ b/spree_digital.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'spree_api'
-  s.add_dependency 'spree_backend', '~> 3.0.0'
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_backend', '~> 3.1.0.beta'
+  s.add_dependency 'spree_core', '~> 3.1.0.beta'
   s.add_dependency 'spree_frontend'
 
   # test suite


### PR DESCRIPTION
According to Versionfile, master branch is compatible with spree 3.1  but gemspec was still set at `~> 3.0.0` and Gemfile pointed to `spree/spree, branch: '3-0-stable'`