### PR TITLE
bump version to 3.2.0.alpha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '3-1-stable'
+gem 'spree', github: 'spree/spree', branch: 'master'
 
 gemspec
 

--- a/spree_digital.gemspec
+++ b/spree_digital.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.name         = 'spree_digital'
-  s.version      = '3.1.0'
+  s.version      = '3.2.0.alpha'
   s.summary      = ''
   s.description  = 'Digital download functionality for spree'
   s.authors      = ['funkensturm', 'Michael Bianco']
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
   s.required_ruby_version = '>= 2.1.0'
 
-  spree_version = '~> 3.1.0.beta'
+  spree_version = '~> 3.2.0.alpha'
   s.add_dependency 'spree_api', spree_version
   s.add_dependency 'spree_backend', spree_version
   s.add_dependency 'spree_core', spree_version


### PR DESCRIPTION
- bump version to 3.2.0.alpha
- change spree dependency version to 3.2.0.alpha
- change spree branch to master