### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_digital.gemspec
+++ b/spree_digital.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_frontend', spree_version
   s.add_dependency 'spree_extension'
+  s.add_dependency 'deface', '~> 1.0'
 
   # test suite
   s.add_development_dependency 'shoulda-matchers'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here